### PR TITLE
Refactor MenuList initialization for compatibility

### DIFF
--- a/NeoBoot/files/i_neo.py
+++ b/NeoBoot/files/i_neo.py
@@ -175,10 +175,19 @@ class ImageManager(Screen):
 			self.mtdboot = SystemInfo["MBbootdevice"]
 		self.onChangedEntry = []
 		if choices:
-			self["list"] = MenuList(list=[((_("No images found on the selected download server...if password check validity")), "Waiter")])
-
+			# self["list"] = MenuList(list=[((_("No images found on the selected download server...if password check validity")), "Waiter")])
+			try:
+				# Python 3
+				self["list"] = MenuList([(_("No images found on the selected download server...if password check validity"), "Waiter")])
+			except TypeError:
+				# Python 2 fallback
+				self["list"] = MenuList(list=[(_("No images found on the selected download server...if password check validity"), "Waiter")])
 		else:
-			self["list"] = MenuList(list=[((_(" Press 'Menu' to select a storage device - none available")), "Waiter")])
+			# self["list"] = MenuList(list=[((_(" Press 'Menu' to select a storage device - none available")), "Waiter")])
+			try:
+				self["list"] = MenuList([(_(" Press 'Menu' to select a storage device - none available"), "Waiter")])
+			except TypeError:
+				self["list"] = MenuList(list=[(_(" Press 'Menu' to select a storage device - none available"), "Waiter")])
 			self["key_red"].hide()
 			self["key_green"].hide()
 			self["key_yellow"].hide()


### PR DESCRIPTION
to repair python crash

06:31:00.8161 Traceback (most recent call last):
06:31:00.8162   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 278, in action
06:31:00.8189   File "/usr/lib/enigma2/python/Plugins/Extensions/NeoBoot/plugin.py", line 298, in DownloadImageOnline
06:31:00.8210     self.session.open(ImageManager)
06:31:00.8213   File "/usr/lib/enigma2/python/StartEnigma.py", line 174, in open
06:31:00.8227     dialog = self.current_dialog = self.instantiateDialog(screen, *arguments, **kwargs)
06:31:00.8234                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:31:00.8235   File "/usr/lib/enigma2/python/StartEnigma.py", line 110, in instantiateDialog
06:31:00.8241     return self.doInstantiateDialog(screen, arguments, kwargs, self.desktop)
06:31:00.8247            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:31:00.8247   File "/usr/lib/enigma2/python/StartEnigma.py", line 133, in doInstantiateDialog
06:31:00.8253     dialog = screen(self, *arguments, **kwargs)  # Create dialog.
06:31:00.8257              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:31:00.8258   File "/usr/lib/enigma2/python/Plugins/Extensions/NeoBoot/files/i_neo.py", line 178, in __init__
06:31:00.8264     self["list"] = MenuList(list=[((_("No images found on the selected download server...if password check validity")), "Waiter")])
06:31:00.8273                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:31:00.8274 TypeError: MenuList.__init__() got an unexpected keyword argument 'list'
06:31:00.8274 [ePyObject] (PyObject_CallObject(<bound method ActionMap.action of <Components.ActionMap.ActionMap object at 0x9e2520a8>>,('ColorActions', 'red')) failed)